### PR TITLE
windock 1.0.25

### DIFF
--- a/Formula/windock.rb
+++ b/Formula/windock.rb
@@ -1,0 +1,32 @@
+class Windock < Formula
+  desc "Windows 11-style taskbar for macOS"
+  homepage "https://github.com/barnuri/win-dock"
+  url "https://github.com/barnuri/win-dock/releases/download/v1.0.25/WinDock.zip"
+  version "1.0.25"
+  sha256 "13d16440c0e316950df2a65f7bae362116d436b8f73421c5bb2ad4134660579c"
+
+  depends_on macos: ">= :sonoma"
+
+  def install
+    prefix.install "WinDock.app"
+  end
+
+  def caveats
+    <<~EOS
+      WinDock has been installed to:
+        #{prefix}/WinDock.app
+
+      To run WinDock, you can either:
+      1. Open it from Finder: #{prefix}/WinDock.app
+      2. Use the open command: open "#{prefix}/WinDock.app"
+
+      To add WinDock to your Applications folder, create a symlink:
+        ln -sf "#{prefix}/WinDock.app" /Applications/WinDock.app
+    EOS
+  end
+
+  test do
+    assert_predicate prefix/"WinDock.app", :exist?
+    assert_predicate prefix/"WinDock.app/Contents/Info.plist", :exist?
+  end
+end


### PR DESCRIPTION
Update WinDock to version 1.0.25

**Formula Details:**
- Version: 1.0.25
- Homepage: https://github.com/barnuri/win-dock
- Download URL: https://github.com/barnuri/win-dock/releases/download/v1.0.25/WinDock.zip

**Testing:**
- [x] Formula passes `brew audit --strict windock`
- [x] Formula installs correctly
- [x] Application launches successfully

This update provides the latest version of WinDock via the Homebrew tap.
